### PR TITLE
fix: 壊れた件名

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,11 +55,11 @@ const sendDiscordNotification = async (
   const to = formatAddresses(email.to)
   const cc = formatAddresses(email.cc)
   const bcc = formatAddresses(email.bcc)
-  const subject = message.headers.get("subject")
+  const subject = formatEmailSubject(email)
 
   const markdownBody = convertEmailToMarkdown(email)
   const headerLines = [
-    `件名: ${subject || "No Subject"}`,
+    `件名: ${subject}`,
     `From: ${from}`,
     `To: ${to}`,
     `CC: ${cc}`,
@@ -73,6 +73,8 @@ const sendDiscordNotification = async (
 
   await sendDiscordChunks(chunks, webhookUrls)
 }
+
+const formatEmailSubject = (email: PostalMime.Email): string => email.subject || "No Subject"
 
 const formatAddresses = (addresses: PostalMime.Address[] | undefined): string => {
   if (!addresses || addresses.length === 0) {

--- a/test/email-subject.spec.ts
+++ b/test/email-subject.spec.ts
@@ -1,0 +1,33 @@
+import PostalMime from "postal-mime";
+import { describe, expect, it } from "vitest";
+import { formatEmailSubject } from "../src/index";
+
+describe("email subject formatting", () => {
+	it("uses decoded MIME encoded-word subject", async () => {
+		const parser = new PostalMime();
+		const email = await parser.parse(
+			[
+				"From: Sender <sender@example.com>",
+				"To: Receiver <receiver@example.com>",
+				"Subject: =?utf-8?b?SW5jcmVhc2VkIGNvbmN1cnJlbmN5IGZvciBzZXJ2aWNlIHVzZXJz?=",
+				"",
+				"Body",
+			].join("\r\n"),
+		);
+
+		expect(formatEmailSubject(email)).toBe(
+			"Increased concurrency for service users",
+		);
+	});
+
+	it("returns default text when subject is missing", () => {
+		expect(
+			formatEmailSubject({
+				headers: [],
+				from: { name: "", address: "sender@example.com" },
+				messageId: "",
+				attachments: [],
+			}),
+		).toBe("No Subject");
+	});
+});


### PR DESCRIPTION
  1. postal-mime公式ドキュメントに、email.headers[].valueはエンコード語を復号しない一方で、
     email.subjectは復号済みになると明記されています。例でもemail.subjectがHello Worldになりま
     す。
     出典: https://postal-mime.postalsys.com/docs/api/types/

  2. postal-mimeの実装でも、subjectを含むヘッダーはdecodeWords(header.value)を通して
     message.subjectに入れています。
     出典: https://github.com/postalsys/postal-mime

  なので、message.headers.get("subject")を使う現在の実装は生のMIMEヘッダーを表示してしまいます。修正としては、パース後のemail.subjectを使うのが正しいです。
